### PR TITLE
As per json spec, there is no need to escape a single quote

### DIFF
--- a/korlibs-serialization/src/korlibs/io/serialization/json/Json.kt
+++ b/korlibs-serialization/src/korlibs/io/serialization/json/Json.kt
@@ -245,7 +245,7 @@ open class Json {
         b.append('"')
         for (c in str) {
             when (c) {
-                '\\' -> b.append("\\\\"); '/' -> b.append("\\/"); '\'' -> b.append("\\'")
+                '\\' -> b.append("\\\\"); '/' -> b.append("\\/");
                 '"' -> b.append("\\\""); '\b' -> b.append("\\b"); '\u000c' -> b.append("\\f")
                 '\n' -> b.append("\\n"); '\r' -> b.append("\\r"); '\t' -> b.append("\\t")
                 else -> b.append(c)

--- a/korlibs-serialization/test/korlibs/io/serialization/json/JsonTest.kt
+++ b/korlibs-serialization/test/korlibs/io/serialization/json/JsonTest.kt
@@ -46,4 +46,12 @@ class JsonTest {
 	fun decodeUnicode() {
 		assertEquals("aeb", Json.parse(""" "a\u0065b" """))
 	}
+
+	@kotlin.test.Test
+	fun stringify1(){
+		assertEquals(
+			"""{"str":"'","int":1,"bool":true}""",
+			Json.stringify(Json.parse("""{"str":"'","int":1,"bool":true}"""))
+		)
+	}
 }


### PR DESCRIPTION
While using stringify of korlibs to convert the korlibs json to string, when a single quote is present it is escaped which is not as per the JSON spec. This causes error when that json string is parsed by other parsers

Sample code to reproduce this scenario:

```
var KorLibsJson = korlibs.io.serialization.json.Json

@Serializable
class TestClass(var str: String)

@Test
fun testSerialization(){
    var str = """{
      "str": "'"
    }"""
    var json = Json{
        isLenient = true
        ignoreUnknownKeys = true
    }
    var korLibsObj = KorLibsJson.parse(str)
    var kotlinxObj = json.decodeFromString<TestClass>(KorLibsJson.stringify(korLibsObj))
}
```

So with this PR, have removed the logic to escape the single quote when using stringify